### PR TITLE
Update obabel executable to latest dev build

### DIFF
--- a/cmake/DownloadOBabel.cmake
+++ b/cmake/DownloadOBabel.cmake
@@ -11,21 +11,21 @@ macro(DownloadOBabel)
 
   # If it already exists, don't download it again
   if(NOT EXISTS ${CMAKE_BINARY_DIR}/bin/${OBABEL_NAME} AND NOT USE_SYSTEM_OBABEL)
-     set(OBABEL_V "openbabel-2-4-90-static-obabel-executables")
+     set(OBABEL_V "v2.4.90-2")
     # Linux
     if(UNIX AND NOT APPLE)
       set(OBABEL_DOWNLOAD_LOCATION "https://github.com/psavery/openbabel/releases/download/${OBABEL_V}/linux64-obabel")
-      set(MD5 "6c49c049d0e159f7c66e97e982dff792")
+      set(MD5 "5a184619159099fd19c1992efb664994")
 
     # Apple
     elseif(APPLE)
       set(OBABEL_DOWNLOAD_LOCATION "https://github.com/psavery/openbabel/releases/download/${OBABEL_V}/osx64-obabel")
-      set(MD5 "8b7779da046a0f48847f5c1cf9b9c659")
+      set(MD5 "74bbf0e037ccb5b4a47234adf5f8434e")
 
     # Windows
     elseif(WIN32 AND NOT CYGWIN)
       set(OBABEL_DOWNLOAD_LOCATION "https://github.com/psavery/openbabel/releases/download/${OBABEL_V}/win64-obabel.exe")
-      set(MD5 "6cd08c875d4b15d1f07cf5342b5bce44")
+      set(MD5 "3aca1cef116ef8548d700097088e656f")
 
     else()
       message(FATAL_ERROR "OBabel is not supported with the current OS type!")


### PR DESCRIPTION
This is done primarily so that ADF 2018 can be read properly.