### PR TITLE
Add better error detection to generic optimizer

### DIFF
--- a/src/xtalopt/optimizers/generic.cpp
+++ b/src/xtalopt/optimizers/generic.cpp
@@ -50,4 +50,37 @@ GenericOptimizer::GenericOptimizer(OptBase* parent, const QString& filename)
   readSettings(filename);
 }
 
+bool GenericOptimizer::read(Structure* structure, const QString& filename)
+{
+  // Call the base class read() function
+  if (!Optimizer::read(structure, filename)) {
+    qDebug() << "In" << __FUNCTION__ << ": Optimizer::read() failed!";
+    return false;
+  }
+
+  // Now perform some safety checks
+  // There should always be some atoms
+  if (structure->numAtoms() == 0) {
+    qDebug() << "Error: there are no atoms in generic output file:"
+             << filename;
+    return false;
+  }
+
+  // There should be a unit cell
+  if (!structure->hasUnitCell()) {
+    qDebug() << "Error: no unit cell was found in the generic output file:"
+             << filename;
+    return false;
+  }
+
+  // An energy/enthalpy should have been set
+  if (!structure->hasEnthalpy() && structure->getEnergy() == 0) {
+    qDebug() << "Error: enthalpy and energy were not found in the generic"
+             << "output file:" << filename;
+    return false;
+  }
+
+  return true;
+}
+
 } // end namespace XtalOpt

--- a/src/xtalopt/optimizers/generic.h
+++ b/src/xtalopt/optimizers/generic.h
@@ -40,6 +40,11 @@ public:
     *success = true;
     return true;
   };
+
+  // Override the read() function so we can produce an error in the case that
+  // some parts were not set.
+  bool read(GlobalSearch::Structure* structure,
+            const QString& filename) override;
 };
 
 } // end namespace XtalOpt


### PR DESCRIPTION
Now, the generic optimizer will check that the following are true
in the updated structure (after optimization is complete):

1. The structure has more than zero atoms.
2. The structure has a unit cell.
3. The structure has energy or enthalpy.

If any one of these is false, then the generic optimizer treats the
optimization as a failure.

Still, not every error will be caught, because sometimes
Open Babel will read all the parts successfully from an output
file even though the job failed. In this case, the XtalOpt user
can write lines in the job script after the optimizer step to
make sure that the output is complete - and just rename the output
to something other than "job.out" if the output is not complete.